### PR TITLE
Missing constructor parameter on Listeners throws fatal error

### DIFF
--- a/src/NewRelic/Module.php
+++ b/src/NewRelic/Module.php
@@ -50,7 +50,7 @@ class Module implements
         $backgroundJobListener = $serviceManager->get('NewRelic\BackgroundJobListener');
         $eventManager->attach($backgroundJobListener);
 
-	$moduleOptions = $serviceManager->get('NewRelic\ModuleOptions');
+        $moduleOptions = $serviceManager->get('NewRelic\ModuleOptions');
 
         $requestListener = new RequestListener($moduleOptions, $client);
         $eventManager->attach($requestListener);


### PR DESCRIPTION
Composer pulled your most recent changes in 1.1.1 but when refactoring Configuration/Options seems you missed a bit.

PHP Catchable fatal error:  Argument 1 passed to NewRelic\Listener\AbstractListener::__construct() must implement interface NewRelic\ModuleOptionsInterface, instance of NewRelic\Client given

Works after these changes.
