### PR TITLE
Bugfix for accessing non-existant getControllerName() and getActionName() methods

### DIFF
--- a/src/NewRelic/Listener/AbstractTransactionListener.php
+++ b/src/NewRelic/Listener/AbstractTransactionListener.php
@@ -39,8 +39,8 @@ abstract class AbstractTransactionListener extends AbstractListener
         $serviceManager = $e->getApplication()->getServiceManager();
         $request = $serviceManager->get('request');
 
-        $controllerName = $request->getControllerName();
-        $actionName = $request->getActionName();
+        $controllerName = $routeMatch->getParam('controller', 'not-found');
+        $actionName = $routeMatch->getParam('action', 'not-found');
 
         if (
             isset($this->transactions['controllers'])


### PR DESCRIPTION
After fixing the other problem, I then hit this:

PHP Fatal error:  Call to undefined method Zend\Http\PhpEnvironment\Request::getControllerName() in /var/www/hobzy-findandcraft_com-3eca1a6822f7/vendor/neeckeloo/newrelic/src/NewRelic/Listener/AbstractTransactionListener.php on line 42

There isn't a getControllerName() or getActionName() in https://github.com/zendframework/zf2/blob/master/library/Zend/Http/PhpEnvironment/Request.php so I presume you meant to fetch the variables from the routematch variable that's set earlier.

This commit fixes that, however I then hit another fatal:

PHP Fatal error:  Uncaught exception 'Zend\ServiceManager\Exception\ServiceNotFoundException' with message 'Zend\ServiceManager\ServiceManager::get was unable to fetch or create an instance for NewRelic\ModuleOptions' 

After fixing that I got another fatal, I can't put more time towards fixing things at the moment so I'm downgrading to the 1.0.1 release for a while.
