### PR TITLE
Update Module.php for PSR-4

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -13,7 +13,7 @@ class Module implements
 {
     public function getConfig()
     {
-        return include __DIR__ . '/../../config/module.config.php';
+        return require_once(__DIR__ . '/../../config/module.config.php');
     }
 
     public function getAutoloaderConfig()


### PR DESCRIPTION
Going with a PSR-4 loaded means that you are one directory up from where you used to be. Since everything breaks if this file isn't included, might as well have it as a require_once().