### PR TITLE
Proposal of more flexible way to define transaction name

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The current route is used to set the name of each transaction. Moreover, the mod
 Requirements
 ------------
 
-* PHP ^7.0
+* PHP ^7.1
 * Zend Framework
 
 Installation
@@ -86,6 +86,34 @@ return [
 
 Usage
 -----
+
+### Define transaction name
+
+The module use `NewRelic\Listener\RequestListener` to specify the transaction name automatically using matched route name by default.
+
+#### Transaction name providers
+
+The transaction name is retrieved from a provider (`NewRelic\TransactionNameProvider\RouteNameProvider` by default) defined in the configuration.
+
+```php
+use NewRelic\TransactionNameProvider\RouteNameProvider;
+
+return [
+    'newrelic' => [
+        'transaction_name_provider' => RouteNameProvider::class,
+    ],
+];
+```
+
+The package contains some providers:
+
+- RouteNameProvider
+- HttpRequestUrlProvider
+- NullProvider
+
+#### Specify transaction name manually
+
+You can also defined the transaction name yourself by defining `NullProvider` as transaction name provider and using `nameTransaction` method of the client.
 
 ### Ignore transactions
 

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,4 +1,7 @@
 <?php
+
+use NewRelic\TransactionNameProvider\RouteNameProvider;
+
 return [
     'newrelic' => [
         'application_name' => getenv('NEW_RELIC_APP_NAME') ?: null,
@@ -14,6 +17,7 @@ return [
             'NewRelic\RequestListener',
             'NewRelic\ResponseListener',
         ],
+        'transaction_name_provider' => RouteNameProvider::class,
     ],
     'service_manager' => [
         'invokables' => [

--- a/config/newrelic.local.php.dist
+++ b/config/newrelic.local.php.dist
@@ -40,5 +40,10 @@ return [
          * Defines transactions that does not generate apdex metrics
          */
         'ignored_apdex' => [],
+
+        /**
+         * Defines transaction name provider used to define transaction name
+         */
+        // 'transaction_name_provider' => '',
     ],
 ];

--- a/src/Factory/RequestListenerFactory.php
+++ b/src/Factory/RequestListenerFactory.php
@@ -11,6 +11,10 @@ class RequestListenerFactory
         $client  = $container->get('NewRelic\Client');
         $options = $container->get('NewRelic\ModuleOptions');
 
-        return new RequestListener($client, $options);
+        $transactionNameProvider = $container->get(
+            $options->getTransactionNameProvider()
+        );
+
+        return new RequestListener($client, $options, $transactionNameProvider);
     }
 }

--- a/src/Listener/AbstractListener.php
+++ b/src/Listener/AbstractListener.php
@@ -14,10 +14,8 @@ abstract class AbstractListener implements ListenerAggregateInterface
 
     protected $options;
 
-    public function __construct(
-        ClientInterface $client,
-        ModuleOptionsInterface $options
-    ) {
+    public function __construct(ClientInterface $client, ModuleOptionsInterface $options)
+    {
         $this->client  = $client;
         $this->options = $options;
     }

--- a/src/ModuleOptions.php
+++ b/src/ModuleOptions.php
@@ -51,6 +51,11 @@ class ModuleOptions extends AbstractOptions implements ModuleOptionsInterface
     protected $listeners = [];
 
     /**
+     * @var string
+     */
+    protected $transactionNameProvider;
+
+    /**
      * {@inheritdoc}
      */
     public function setApplicationName($name)
@@ -210,5 +215,23 @@ class ModuleOptions extends AbstractOptions implements ModuleOptionsInterface
     public function getListeners()
     {
         return $this->listeners;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setTransactionNameProvider($provider)
+    {
+        $this->transactionNameProvider = (string) $provider;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTransactionNameProvider()
+    {
+        return $this->transactionNameProvider;
     }
 }

--- a/src/ModuleOptionsInterface.php
+++ b/src/ModuleOptionsInterface.php
@@ -101,4 +101,15 @@ interface ModuleOptionsInterface
      * @return array
      */
     public function getListeners();
+
+    /**
+     * @param  string $provider
+     * @return self
+     */
+    public function setTransactionNameProvider($provider);
+
+    /**
+     * @return string
+     */
+    public function getTransactionNameProvider();
 }

--- a/src/TransactionNameProvider/HttpRequestUrlProvider.php
+++ b/src/TransactionNameProvider/HttpRequestUrlProvider.php
@@ -1,0 +1,21 @@
+<?php
+namespace NewRelic\TransactionNameProvider;
+
+use Zend\Http\Request;
+use Zend\Mvc\MvcEvent;
+
+class HttpRequestUrlProvider implements TransactionNameProviderInterface
+{
+    /**
+     * {@inheritedDoc}
+     */
+    public function getTransactionName(MvcEvent $event)
+    {
+        $request = $event->getRequest();
+        if (!$request instanceof Request) {
+            return null;
+        }
+
+        return $request->getUriString();
+    }
+}

--- a/src/TransactionNameProvider/NullProvider.php
+++ b/src/TransactionNameProvider/NullProvider.php
@@ -1,0 +1,15 @@
+<?php
+namespace NewRelic\TransactionNameProvider;
+
+use Zend\Mvc\MvcEvent;
+
+class NullProvider implements TransactionNameProviderInterface
+{
+    /**
+     * {@inheritedDoc}
+     */
+    public function getTransactionName(MvcEvent $event)
+    {
+        return null;
+    }
+}

--- a/src/TransactionNameProvider/RouteNameProvider.php
+++ b/src/TransactionNameProvider/RouteNameProvider.php
@@ -1,0 +1,23 @@
+<?php
+namespace NewRelic\TransactionNameProvider;
+
+use Zend\Mvc\MvcEvent;
+use Zend\Mvc\Router\RouteMatch as RouteMatchV2;
+use Zend\Router\RouteMatch;
+
+class RouteNameProvider implements TransactionNameProviderInterface
+{
+    /**
+     * {@inheritedDoc}
+     */
+    public function getTransactionName(MvcEvent $event)
+    {
+        $matches = $event->getRouteMatch();
+
+        if (!$matches instanceof RouteMatch && !$matches instanceof RouteMatchV2) {
+            return null;
+        }
+
+        return $matches->getMatchedRouteName();
+    }
+}

--- a/src/TransactionNameProvider/TransactionNameProviderInterface.php
+++ b/src/TransactionNameProvider/TransactionNameProviderInterface.php
@@ -1,0 +1,13 @@
+<?php
+namespace NewRelic\TransactionNameProvider;
+
+use Zend\Mvc\MvcEvent;
+
+interface TransactionNameProviderInterface
+{
+    /**
+     * @param  MvcEvent $event
+     * @return string
+     */
+    public function getTransactionName(MvcEvent $event);
+}

--- a/tests/ModuleTest.php
+++ b/tests/ModuleTest.php
@@ -1,0 +1,85 @@
+<?php
+namespace NewRelicTest;
+
+use NewRelic\Client;
+use NewRelic\Module;
+use NewRelic\ModuleOptions;
+use NewRelic\Listener\RequestListener;
+use NewRelic\Listener\ResponseListener;
+use NewRelic\TransactionNameProvider\TransactionNameProviderInterface;
+use PHPUnit\Framework\TestCase;
+use Zend\EventManager\EventManager;
+use Zend\Http\Request as HttpRequest;
+use Zend\Http\Response as HttpResponse;
+use Zend\Mvc\ApplicationInterface;
+use Zend\Mvc\MvcEvent;
+use Zend\ServiceManager\ServiceManager;
+
+class ModuleTest extends TestCase
+{
+    protected function getMvcEvent(EventManager $em): MvcEvent
+    {
+        $event = new MvcEvent();
+
+        $serviceManager = new ServiceManager();
+        $serviceManager->setService('EventManager', $em);
+        $serviceManager->setService('Request', new HttpRequest());
+        $serviceManager->setService('Response', new HttpResponse());
+
+        $application = $this->createMock(ApplicationInterface::class);
+        $application->method('getServiceManager')->willReturn($serviceManager);
+        $application->method('getEventManager')->willReturn($em);
+
+        $event->setApplication($application);
+
+        return $event;
+    }
+
+    public function testShouldAttachListenersOnBootstrap()
+    {
+        $listeners = [
+            'NewRelic\RequestListener',
+            'NewRelic\ResponseListener',
+        ];
+
+        $client = $this->createMock(Client::class);
+        $client
+            ->expects($this->once())
+            ->method('extensionLoaded')
+            ->will($this->returnValue(true));
+
+        $moduleOptions = new ModuleOptions([
+            'listeners' => $listeners,
+        ]);
+
+        $eventManager = $this->createMock(EventManager::class);
+        $eventManager
+            ->expects($this->exactly(count($listeners)))
+            ->method('attach');
+
+        $mvcEvent = $this->getMvcEvent($eventManager);
+
+        $serviceManager = $mvcEvent->getApplication()->getServiceManager();
+        $serviceManager->setService(Client::class, $client);
+        $serviceManager->setService(ModuleOptions::class, $moduleOptions);
+        $serviceManager->setService(
+            'NewRelic\RequestListener',
+            new RequestListener($client, $moduleOptions, $this->getTransactionNameProvider())
+        );
+        $serviceManager->setService(
+            'NewRelic\ResponseListener',
+            new ResponseListener($client, $moduleOptions)
+        );
+
+        $module = new Module();
+        $module->onBootstrap($mvcEvent);
+    }
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject|TransactionNameProviderInterface
+     */
+    private function getTransactionNameProvider()
+    {
+        return $this->createMock(TransactionNameProviderInterface::class);
+    }
+}

--- a/tests/TransactionNameProvider/RouteNameProviderTest.php
+++ b/tests/TransactionNameProvider/RouteNameProviderTest.php
@@ -1,0 +1,50 @@
+<?php
+namespace NewRelicTest\TransactionNameProvider;
+
+use NewRelic\TransactionNameProvider\RouteNameProvider;
+use PHPUnit\Framework\TestCase;
+use Zend\Mvc\MvcEvent;
+use Zend\Mvc\Router\RouteMatch as RouteMatchV2;
+use Zend\Router\RouteMatch;
+
+class RouteNameProviderTest extends TestCase
+{
+    public function testGetTransactionNameFromMvcEventWithoutRouteMatchShouldReturnNull()
+    {
+        $routeNameProvider = new RouteNameProvider();
+
+        if (class_exists(RouteMatchV2::class)) {
+            $routeMatch = new RouteMatchV2([]);
+        } else {
+            $routeMatch = new RouteMatch([]);
+        }
+
+        $event = new MvcEvent();
+        $event->setRouteMatch($routeMatch);
+
+        $transactionName = $routeNameProvider->getTransactionName($event);
+
+        $this->assertNull($transactionName);
+    }
+
+    public function testGetTransactionNameFromMvcEventWithRouteMatchShouldReturnRouteName()
+    {
+        $routeName = 'foo';
+        $routeNameProvider = new RouteNameProvider();
+
+        if (class_exists(RouteMatchV2::class)) {
+            $routeMatch = new RouteMatchV2([]);
+        } else {
+            $routeMatch = new RouteMatch([]);
+        }
+
+        $routeMatch->setMatchedRouteName($routeName);
+
+        $event = new MvcEvent();
+        $event->setRouteMatch($routeMatch);
+
+        $transactionName = $routeNameProvider->getTransactionName($event);
+
+        $this->assertEquals($transactionName, $routeName);
+    }
+}


### PR DESCRIPTION
The module use `NewRelic\Listener\RequestListener` to specify the transaction name automatically using matched route name by default.
#### Transaction name providers

The transaction name is retrieved from a provider (`NewRelic\TransactionNameProvider\RouteNameProvider` by default) defined in the configuration.

``` php
return [
    'newrelic' => [
        'transaction_name_provider' => 'NewRelic\TransactionNameProvider\RouteNameProvider',
    ],
];
```

The package contains some providers:
- RouteNameProvider
- HttpRequestUrlProvider
- NullProvider
#### Specify transaction name manually

You can also defined the transaction name yourself by defining `NullProvider` as transaction name provider and using `nameTransaction` method of the client.
