### PR TITLE
ZF2 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,16 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "container-interop/container-interop": "^1.1.0",
-        "monolog/monolog": "~1.17",
-        "zendframework/zend-console": "~2.6",
-        "zendframework/zend-eventmanager": "~3.0",
-        "zendframework/zend-http": "~2.5",
-        "zendframework/zend-mvc": "~3.0",
-        "zendframework/zend-stdlib": "~3.0"
+        "monolog/monolog": "^1.17",
+        "zendframework/zend-console": "^2.6",
+        "zendframework/zend-eventmanager": "^2.6 || ^3.0",
+        "zendframework/zend-servicemanager": "^2.7 || ^3.0",
+        "zendframework/zend-http": "^2.5",
+        "zendframework/zend-mvc": "^2.7 || ^3.0",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.4",
+        "phpunit/phpunit": "^5.4",
         "satooshi/php-coveralls": "dev-master"
     },
     "autoload": {

--- a/src/Factory/BackgroundJobListenerFactory.php
+++ b/src/Factory/BackgroundJobListenerFactory.php
@@ -4,15 +4,28 @@ namespace NewRelic\Factory;
 use Interop\Container\ContainerInterface;
 use NewRelic\Listener\BackgroundJobListener;
 use NewRelic\TransactionMatcher;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
-class BackgroundJobListenerFactory
+class BackgroundJobListenerFactory implements FactoryInterface
 {
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         $client  = $container->get('NewRelic\Client');
         $options = $container->get('NewRelic\ModuleOptions');
         $transactionMatcher = new TransactionMatcher($options->getBackgroundJobs());
 
         return new BackgroundJobListener($client, $options, $transactionMatcher);
+    }
+
+    /**
+     * Create service
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return BackgroundJobListener
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator, BackgroundJobListener::class);
     }
 }

--- a/src/Factory/ErrorListenerFactory.php
+++ b/src/Factory/ErrorListenerFactory.php
@@ -3,15 +3,28 @@ namespace NewRelic\Factory;
 
 use Interop\Container\ContainerInterface;
 use NewRelic\Listener\ErrorListener;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
-class ErrorListenerFactory
+class ErrorListenerFactory implements FactoryInterface
 {
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         $client  = $container->get('NewRelic\Client');
         $options = $container->get('NewRelic\ModuleOptions');
         $logger  = $container->get('NewRelic\Logger');
 
         return new ErrorListener($client, $options, $logger);
+    }
+
+    /**
+     * Create service
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return ErrorListener
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator, ErrorListener::class);
     }
 }

--- a/src/Factory/IgnoreApdexListenerFactory.php
+++ b/src/Factory/IgnoreApdexListenerFactory.php
@@ -4,15 +4,28 @@ namespace NewRelic\Factory;
 use Interop\Container\ContainerInterface;
 use NewRelic\Listener\IgnoreApdexListener;
 use NewRelic\TransactionMatcher;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
-class IgnoreApdexListenerFactory
+class IgnoreApdexListenerFactory implements FactoryInterface
 {
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         $client  = $container->get('NewRelic\Client');
         $options = $container->get('NewRelic\ModuleOptions');
         $transactionMatcher = new TransactionMatcher($options->getIgnoredApdex());
 
         return new IgnoreApdexListener($client, $options, $transactionMatcher);
+    }
+
+    /**
+     * Create service
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return IgnoreApdexListener
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator, IgnoreApdexListener::class);
     }
 }

--- a/src/Factory/IgnoreTransactionListenerFactory.php
+++ b/src/Factory/IgnoreTransactionListenerFactory.php
@@ -4,15 +4,28 @@ namespace NewRelic\Factory;
 use Interop\Container\ContainerInterface;
 use NewRelic\Listener\IgnoreTransactionListener;
 use NewRelic\TransactionMatcher;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
-class IgnoreTransactionListenerFactory
+class IgnoreTransactionListenerFactory implements FactoryInterface
 {
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         $client  = $container->get('NewRelic\Client');
         $options = $container->get('NewRelic\ModuleOptions');
         $transactionMatcher = new TransactionMatcher($options->getIgnoredTransactions());
 
         return new IgnoreTransactionListener($client, $options, $transactionMatcher);
+    }
+
+    /**
+     * Create service
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return IgnoreTransactionListener
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator, IgnoreTransactionListener::class);
     }
 }

--- a/src/Factory/LoggerFactory.php
+++ b/src/Factory/LoggerFactory.php
@@ -1,16 +1,30 @@
 <?php
 namespace NewRelic\Factory;
 
+use Interop\Container\ContainerInterface;
 use Monolog\Logger;
 use Monolog\Handler\NewRelicHandler;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
-class LoggerFactory
+class LoggerFactory implements FactoryInterface
 {
-    public function __invoke()
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         $logger = new Logger('newrelic');
         $logger->pushHandler(new NewRelicHandler());
 
         return $logger;
+    }
+
+    /**
+     * Create service
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return Logger
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator, Logger::class);
     }
 }

--- a/src/Factory/ModuleOptionsFactory.php
+++ b/src/Factory/ModuleOptionsFactory.php
@@ -4,10 +4,12 @@ namespace NewRelic\Factory;
 use Interop\Container\ContainerInterface;
 use NewRelic\Exception\RuntimeException;
 use NewRelic\ModuleOptions;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
-class ModuleOptionsFactory
+class ModuleOptionsFactory implements FactoryInterface
 {
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         $config = $container->get('Config');
 
@@ -18,5 +20,16 @@ class ModuleOptionsFactory
         }
 
         return new ModuleOptions($config['newrelic']);
+    }
+
+    /**
+     * Create service
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return ModuleOptions
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator, ModuleOptions::class);
     }
 }

--- a/src/Factory/RequestListenerFactory.php
+++ b/src/Factory/RequestListenerFactory.php
@@ -3,14 +3,27 @@ namespace NewRelic\Factory;
 
 use Interop\Container\ContainerInterface;
 use NewRelic\Listener\RequestListener;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
-class RequestListenerFactory
+class RequestListenerFactory implements FactoryInterface
 {
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         $client  = $container->get('NewRelic\Client');
         $options = $container->get('NewRelic\ModuleOptions');
 
         return new RequestListener($client, $options);
+    }
+
+    /**
+     * Create service
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return RequestListener
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator, RequestListener::class);
     }
 }

--- a/src/Factory/ResponseListenerFactory.php
+++ b/src/Factory/ResponseListenerFactory.php
@@ -3,14 +3,27 @@ namespace NewRelic\Factory;
 
 use Interop\Container\ContainerInterface;
 use NewRelic\Listener\ResponseListener;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
-class ResponseListenerFactory
+class ResponseListenerFactory implements FactoryInterface
 {
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         $client  = $container->get('NewRelic\Client');
         $options = $container->get('NewRelic\ModuleOptions');
 
         return new ResponseListener($client, $options);
+    }
+
+    /**
+     * Create service
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return ResponseListener
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator, ResponseListener::class);
     }
 }

--- a/src/Listener/AbstractTransactionListener.php
+++ b/src/Listener/AbstractTransactionListener.php
@@ -28,6 +28,6 @@ abstract class AbstractTransactionListener extends AbstractListener
      */
     protected function isMatchedRequest(MvcEvent $e)
     {
-        return $this->transactionMatcher->isMatched($e->getRouteMatch());
+        return $this->transactionMatcher->isMatched($e);
     }
 }

--- a/src/Listener/RequestListener.php
+++ b/src/Listener/RequestListener.php
@@ -4,6 +4,7 @@ namespace NewRelic\Listener;
 use Zend\EventManager\EventManagerInterface as Events;
 use Zend\Mvc\MvcEvent;
 use Zend\Router\RouteMatch;
+use Zend\Mvc\Router\RouteMatch as RouteMatchV2;
 
 class RequestListener extends AbstractListener
 {
@@ -29,7 +30,7 @@ class RequestListener extends AbstractListener
         }
 
         $matches = $e->getRouteMatch();
-        if ($matches instanceof RouteMatch) {
+        if ($matches instanceof RouteMatch || $matches instanceof RouteMatchV2) {
             $route = $matches->getMatchedRouteName();
             $this->client->nameTransaction($route);
         }

--- a/src/Module.php
+++ b/src/Module.php
@@ -1,6 +1,7 @@
 <?php
 namespace NewRelic;
 
+use Zend\EventManager\ListenerAggregateInterface;
 use Zend\Loader\StandardAutoloader;
 use Zend\Mvc\MvcEvent;
 
@@ -37,8 +38,9 @@ class Module
 
         $moduleOptions = $serviceManager->get(ModuleOptions::class);
         foreach ($moduleOptions->getListeners() as $service) {
+            /** @var ListenerAggregateInterface $listener */
             $listener = $serviceManager->get($service);
-            $eventManager->attach($listener);
+            $listener->attach($eventManager);
         }
     }
 }

--- a/src/TransactionMatcher.php
+++ b/src/TransactionMatcher.php
@@ -1,7 +1,7 @@
 <?php
 namespace NewRelic;
 
-use Zend\Router\RouteMatch;
+use Zend\Mvc\MvcEvent;
 
 class TransactionMatcher implements TransactionMatcherInterface
 {
@@ -16,11 +16,12 @@ class TransactionMatcher implements TransactionMatcherInterface
     }
 
     /**
-     * @param  RouteMatch $routeMatch
+     * @param  MvcEvent $mvcEvent
      * @return bool
      */
-    public function isMatched(RouteMatch $routeMatch)
+    public function isMatched(MvcEvent $mvcEvent)
     {
+        $routeMatch = $mvcEvent->getRouteMatch();
         $matchedRouteName = $routeMatch->getMatchedRouteName();
         if ($this->isRouteMatched($matchedRouteName)) {
             return true;

--- a/src/TransactionMatcherInterface.php
+++ b/src/TransactionMatcherInterface.php
@@ -1,13 +1,13 @@
 <?php
 namespace NewRelic;
 
-use Zend\Router\RouteMatch;
+use Zend\Mvc\MvcEvent;
 
 interface TransactionMatcherInterface
 {
     /**
-     * @param  RouteMatch $routeMatch
+     * @param  MvcEvent $mvcEvent
      * @return bool
      */
-    public function isMatched(RouteMatch $routeMatch);
+    public function isMatched(MvcEvent $mvcEvent);
 }

--- a/tests/Factory/BackgroundJobListenerFactoryTest.php
+++ b/tests/Factory/BackgroundJobListenerFactoryTest.php
@@ -20,7 +20,7 @@ class BackgroundJobListenerFactoryTest extends \PHPUnit_Framework_TestCase
         );
         $backgroundJobListenerFactory = new BackgroundJobListenerFactory();
 
-        $listener = $backgroundJobListenerFactory($container->reveal());
+        $listener = $backgroundJobListenerFactory($container->reveal(), BackgroundJobListener::class);
 
         $this->assertInstanceOf(BackgroundJobListener::class, $listener);
     }

--- a/tests/Factory/ErrorListenerFactoryTest.php
+++ b/tests/Factory/ErrorListenerFactoryTest.php
@@ -24,7 +24,7 @@ class ErrorListenerFactoryTest extends \PHPUnit_Framework_TestCase
         );
         $errorListenerFactory = new ErrorListenerFactory();
 
-        $listener = $errorListenerFactory($container->reveal());
+        $listener = $errorListenerFactory($container->reveal(), ErrorListener::class);
 
         $this->assertInstanceOf(ErrorListener::class, $listener);
     }

--- a/tests/Factory/IgnoreApdexListenerFactoryTest.php
+++ b/tests/Factory/IgnoreApdexListenerFactoryTest.php
@@ -20,7 +20,7 @@ class IgnoreApdexListenerFactoryTest extends \PHPUnit_Framework_TestCase
         );
         $ignoreApdexListenerFactory = new IgnoreApdexListenerFactory();
 
-        $listener = $ignoreApdexListenerFactory($container->reveal());
+        $listener = $ignoreApdexListenerFactory($container->reveal(), IgnoreApdexListener::class);
 
         $this->assertInstanceOf(IgnoreApdexListener::class, $listener);
     }

--- a/tests/Factory/IgnoreTransactionListenerFactoryTest.php
+++ b/tests/Factory/IgnoreTransactionListenerFactoryTest.php
@@ -20,7 +20,7 @@ class IgnoreTransactionListenerFactoryTest extends \PHPUnit_Framework_TestCase
         );
         $ignoreTransactionListenerFactory = new IgnoreTransactionListenerFactory();
 
-        $listener = $ignoreTransactionListenerFactory($container->reveal());
+        $listener = $ignoreTransactionListenerFactory($container->reveal(), IgnoreTransactionListener::class);
         $this->assertInstanceOf(IgnoreTransactionListener::class, $listener);
     }
 

--- a/tests/Factory/LoggerFactoryTest.php
+++ b/tests/Factory/LoggerFactoryTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace NewRelicTest\Factory;
 
+use Interop\Container\ContainerInterface;
 use NewRelic\Factory\LoggerFactory;
 use Psr\Log\LoggerInterface;
 
@@ -8,9 +9,10 @@ class LoggerFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testCreateServiceShouldReturnPsrLoggerInstance()
     {
+        $container = $this->prophesize(ContainerInterface::class);
         $loggerFactory = new LoggerFactory();
 
-        $logger = $loggerFactory();
+        $logger = $loggerFactory($container->reveal(), LoggerInterface::class);
 
         $this->assertInstanceOf(LoggerInterface::class, $logger);
     }

--- a/tests/Factory/ModuleOptionsFactoryTest.php
+++ b/tests/Factory/ModuleOptionsFactoryTest.php
@@ -20,7 +20,7 @@ class ModuleOptionsFactoryTest extends \PHPUnit_Framework_TestCase
         ]);
         $moduleOptionsFactory = new ModuleOptionsFactory();
 
-        $moduleOptions = $moduleOptionsFactory($container->reveal());
+        $moduleOptions = $moduleOptionsFactory($container->reveal(), ModuleOptions::class);
 
         $this->assertInstanceOf(ModuleOptions::class, $moduleOptions);
     }
@@ -34,6 +34,6 @@ class ModuleOptionsFactoryTest extends \PHPUnit_Framework_TestCase
         $container->get('Config')->willReturn([]);
         $moduleOptionsFactory = new ModuleOptionsFactory();
 
-        $moduleOptionsFactory($container->reveal());
+        $moduleOptionsFactory($container->reveal(), ModuleOptions::class);
     }
 }

--- a/tests/Listener/BackgroundJobListenerTest.php
+++ b/tests/Listener/BackgroundJobListenerTest.php
@@ -9,6 +9,7 @@ use Zend\Console\Request as ConsoleRequest;
 use Zend\Http\Request as HttpRequest;
 use Zend\Mvc\MvcEvent;
 use Zend\Router\RouteMatch;
+use Zend\Mvc\Router\RouteMatch as RouteMatchV2;
 
 class BackgroundJobListenerTest extends \PHPUnit_Framework_TestCase
 {
@@ -117,7 +118,7 @@ class BackgroundJobListenerTest extends \PHPUnit_Framework_TestCase
     private function getEvent()
     {
         $event = new MvcEvent();
-        $event->setRouteMatch(new RouteMatch([]));
+        $event->setRouteMatch(class_exists(RouteMatch::class) ? new RouteMatch([]) : new RouteMatchV2([]));
 
         return $event;
     }

--- a/tests/Listener/IgnoreTransactionListenerTest.php
+++ b/tests/Listener/IgnoreTransactionListenerTest.php
@@ -7,6 +7,7 @@ use NewRelic\ModuleOptionsInterface;
 use NewRelic\TransactionMatcher;
 use Zend\Mvc\MvcEvent;
 use Zend\Router\RouteMatch;
+use Zend\Mvc\Router\RouteMatch as RouteMatchV2;
 
 class IgnoreTransactionListenerTest extends \PHPUnit_Framework_TestCase
 {
@@ -69,7 +70,7 @@ class IgnoreTransactionListenerTest extends \PHPUnit_Framework_TestCase
     private function getEvent()
     {
         $event = new MvcEvent();
-        $event->setRouteMatch(new RouteMatch([]));
+        $event->setRouteMatch(class_exists(RouteMatch::class) ? new RouteMatch([]) : new RouteMatchV2([]));
 
         return $event;
     }

--- a/tests/Listener/RequestListenerTest.php
+++ b/tests/Listener/RequestListenerTest.php
@@ -6,6 +6,7 @@ use NewRelic\Listener\RequestListener;
 use NewRelic\ModuleOptions;
 use Zend\Mvc\MvcEvent;
 use Zend\Router\RouteMatch;
+use Zend\Mvc\Router\RouteMatch as RouteMatchV2;
 
 class RequestListenerTest extends \PHPUnit_Framework_TestCase
 {
@@ -53,7 +54,7 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('nameTransaction');
 
-        $routeMatch = new RouteMatch([]);
+        $routeMatch = class_exists(RouteMatch::class) ? new RouteMatch([]) : new RouteMatchV2([]);
         $this->event->setRouteMatch($routeMatch);
 
         $this->listener->onRequest($this->event);
@@ -67,7 +68,7 @@ class RequestListenerTest extends \PHPUnit_Framework_TestCase
             ->expects($this->never())
             ->method('setAppName');
 
-        $routeMatch = new RouteMatch([]);
+        $routeMatch = class_exists(RouteMatch::class) ? new RouteMatch([]) : new RouteMatchV2([]);
         $this->event->setRouteMatch($routeMatch);
 
         $this->listener->onRequest($this->event);

--- a/tests/TransactionMatcherTest.php
+++ b/tests/TransactionMatcherTest.php
@@ -2,7 +2,9 @@
 namespace NewRelicTest;
 
 use NewRelic\TransactionMatcher;
+use Zend\Mvc\MvcEvent;
 use Zend\Router\RouteMatch;
+use Zend\Mvc\Router\RouteMatch as RouteMatchV2;
 
 class TransactionMatcherTest extends \PHPUnit_Framework_TestCase
 {
@@ -29,7 +31,10 @@ class TransactionMatcherTest extends \PHPUnit_Framework_TestCase
         $routeMatch = $this->getRouteMatch();
         $transactionMatcher = new TransactionMatcher($transactions);
 
-        $this->assertSame($isMatched, $transactionMatcher->isMatched($routeMatch));
+        $mvcEvent = $this->prophesize(MvcEvent::class);
+        $mvcEvent->getRouteMatch()->shouldBeCalled()->willReturn($routeMatch);
+
+        $this->assertSame($isMatched, $transactionMatcher->isMatched($mvcEvent->reveal()));
     }
 
     public function transactionProvider()
@@ -86,7 +91,7 @@ class TransactionMatcherTest extends \PHPUnit_Framework_TestCase
      */
     private function getRouteMatch()
     {
-        $routeMatch = $this->getMockBuilder(RouteMatch::class)
+        $routeMatch = $this->getMockBuilder(class_exists(RouteMatch::class) ? RouteMatch::class : RouteMatchV2::class)
             ->disableOriginalConstructor()
             ->getMock();
 


### PR DESCRIPTION
This PR enable zf2/zf3 compatibility. It's necessary to use this library while migrating projects from ZF2 to ZF3.
Also fix an error with zend-eventmanager v3 registering a listener.