### PR TITLE
add env var to build with highest AND lowest dependency versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,13 @@ php:
   - 7.0
   - hhvm
 
+env:
+  - COMPOSER_OPTS=""
+  - COMPOSER_OPTS="--prefer-lowest"
+
 before_script:
   - composer self-update
-  - composer install --no-interaction
+  - composer update --no-interaction $COMPOSER_OPTS
 
 script:
   - mkdir -p build/logs


### PR DESCRIPTION
hi Team,

this change will build the highest and lowest dependency versions available in our composer schema for each php version in the travis config. this can help us to ensure the ranges are valid.

what do you think?