### PR TITLE
phpunit whitelist was not working because the referenced subdirectory…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/build
 /nbproject
 /vendor
 composer.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
 
 script:
   - mkdir -p build/logs
-  - vendor/bin/phpunit -c phpunit.xml.dist
+  - vendor/bin/phpunit -c phpunit.xml.dist --coverage-text
 
 after_script:
   - php vendor/bin/coveralls

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,7 +18,7 @@
 
     <filter>
         <whitelist>
-            <directory suffix=".php">src/NewRelic</directory>
+            <directory suffix=".php">src</directory>
         </whitelist>
     </filter>
 


### PR DESCRIPTION
phpunit whitelist was not working because the referenced subdirectory does not actually exist.

* remove non-existent directory from whitelist.
* add build dir to gitignore so that it is not accidentally committed now that it is being generated again.
* add coverage summary to build output.