### PR TITLE
proposal to prefer NEW_RELIC_APP_NAME env var in module config

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,14 @@ return [
     'newrelic' => [
         // Sets the newrelic app name.  Note that this will discard metrics
         // collected before the name is set.  If empty then your php.ini
-        // configuration will take precedence.
-        'application_name' => null,
+        // configuration will take precedence. You can set the value by
+        // environment variable, or by overriding in a local config.
+        'application_name' => getenv('NEW_RELIC_APP_NAME') ?: null,
 
         // May be null and will only be set if application name is also given.
-        'license' => null,
+        // You can set the value by environment variable, or by overriding in 
+        // a local config.
+        'license' => getenv('NEW_RELIC_LICENSE_KEY ') ?: null,
 
         // If false then neither change the auto_instrument or manually
         // instrument the real user monitoring.

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -2,7 +2,7 @@
 return [
     'newrelic' => [
         'application_name' => getenv('NEW_RELIC_APP_NAME') ?: null,
-        'license' => null,
+        'license' => getenv('NEW_RELIC_LICENSE_KEY ') ?: null,
         'browser_timing_enabled' => false,
         'browser_timing_auto_instrument' => true,
         'exceptions_logging_enabled' => false,

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,7 +1,7 @@
 <?php
 return [
     'newrelic' => [
-        'application_name' => null,
+        'application_name' => getenv('NEW_RELIC_APP_NAME') ?: null,
         'license' => null,
         'browser_timing_enabled' => false,
         'browser_timing_auto_instrument' => true,

--- a/config/newrelic.local.php.dist
+++ b/config/newrelic.local.php.dist
@@ -4,12 +4,12 @@ return [
         /**
          * Define the name of the application as it will be seen in the New Relic UI
          */
-        // 'application_name' => getenv('NEW_RELIC_APP_NAME') ?: '',
+        // 'application_name' => getenv('NEW_RELIC_APP_NAME') ?: null,
 
         /**
          * Define the New Relic license key to use
          */
-        // 'license' => '',
+        // 'license' => getenv('NEW_RELIC_LICENSE_KEY ') ?: null,
 
         /**
          * Enable auto-insertion of the JavaScript fragments for browser monitoring

--- a/config/newrelic.local.php.dist
+++ b/config/newrelic.local.php.dist
@@ -4,7 +4,7 @@ return [
         /**
          * Define the name of the application as it will be seen in the New Relic UI
          */
-        // 'application_name' => '',
+        // 'application_name' => getenv('NEW_RELIC_APP_NAME') ?: '',
 
         /**
          * Define the New Relic license key to use


### PR DESCRIPTION
prefer NEW_RELIC_APP_NAME env var in module config, over default `null` or empty string which will defer to the system (php.ini) configuration.

this follows documented convention of New Relic integration in other languages, e.g.:
* https://docs.newrelic.com/docs/agents/manage-apm-agents/app-naming/rename-your-application
* https://docs.newrelic.com/docs/agents/java-agent/configuration/java-agent-configuration-config-file#cfg-app_name

what do you think?