### PR TITLE
Remove interop container refactoring factories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "container-interop/container-interop": "^1.1.0",
+        "psr/container": "1.0",
         "monolog/monolog": "^1.17",
         "zendframework/zend-console": "^2.6",
         "zendframework/zend-eventmanager": "^2.6 || ^3.0",
@@ -27,6 +27,9 @@
     "require-dev": {
         "phpunit/phpunit": "^7.5",
         "php-coveralls/php-coveralls": "^2.0"
+    },
+    "conflict": {
+        "container-interop/container-interop": "<1.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php-coveralls/php-coveralls": "^2.0"
     },
     "conflict": {
-        "container-interop/container-interop": "<1.1"
+        "container-interop/container-interop": "<1.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Factory/BackgroundJobListenerFactory.php
+++ b/src/Factory/BackgroundJobListenerFactory.php
@@ -1,31 +1,18 @@
 <?php
 namespace NewRelic\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use NewRelic\Listener\BackgroundJobListener;
 use NewRelic\TransactionMatcher;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
 
-class BackgroundJobListenerFactory implements FactoryInterface
+class BackgroundJobListenerFactory
 {
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container): BackgroundJobListener
     {
         $client  = $container->get('NewRelic\Client');
         $options = $container->get('NewRelic\ModuleOptions');
         $transactionMatcher = new TransactionMatcher($options->getBackgroundJobs());
 
         return new BackgroundJobListener($client, $options, $transactionMatcher);
-    }
-
-    /**
-     * Create service
-     *
-     * @param ServiceLocatorInterface $serviceLocator
-     * @return BackgroundJobListener
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, BackgroundJobListener::class);
     }
 }

--- a/src/Factory/ErrorListenerFactory.php
+++ b/src/Factory/ErrorListenerFactory.php
@@ -1,30 +1,17 @@
 <?php
 namespace NewRelic\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use NewRelic\Listener\ErrorListener;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
 
-class ErrorListenerFactory implements FactoryInterface
+class ErrorListenerFactory
 {
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container): ErrorListener
     {
         $client  = $container->get('NewRelic\Client');
         $options = $container->get('NewRelic\ModuleOptions');
         $logger  = $container->get('NewRelic\Logger');
 
         return new ErrorListener($client, $options, $logger);
-    }
-
-    /**
-     * Create service
-     *
-     * @param ServiceLocatorInterface $serviceLocator
-     * @return ErrorListener
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, ErrorListener::class);
     }
 }

--- a/src/Factory/IgnoreApdexListenerFactory.php
+++ b/src/Factory/IgnoreApdexListenerFactory.php
@@ -1,31 +1,18 @@
 <?php
 namespace NewRelic\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use NewRelic\Listener\IgnoreApdexListener;
 use NewRelic\TransactionMatcher;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
 
-class IgnoreApdexListenerFactory implements FactoryInterface
+class IgnoreApdexListenerFactory
 {
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container): IgnoreApdexListener
     {
         $client  = $container->get('NewRelic\Client');
         $options = $container->get('NewRelic\ModuleOptions');
         $transactionMatcher = new TransactionMatcher($options->getIgnoredApdex());
 
         return new IgnoreApdexListener($client, $options, $transactionMatcher);
-    }
-
-    /**
-     * Create service
-     *
-     * @param ServiceLocatorInterface $serviceLocator
-     * @return IgnoreApdexListener
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, IgnoreApdexListener::class);
     }
 }

--- a/src/Factory/IgnoreTransactionListenerFactory.php
+++ b/src/Factory/IgnoreTransactionListenerFactory.php
@@ -1,31 +1,18 @@
 <?php
 namespace NewRelic\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use NewRelic\Listener\IgnoreTransactionListener;
 use NewRelic\TransactionMatcher;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
 
-class IgnoreTransactionListenerFactory implements FactoryInterface
+class IgnoreTransactionListenerFactory
 {
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container): IgnoreTransactionListener
     {
         $client  = $container->get('NewRelic\Client');
         $options = $container->get('NewRelic\ModuleOptions');
         $transactionMatcher = new TransactionMatcher($options->getIgnoredTransactions());
 
         return new IgnoreTransactionListener($client, $options, $transactionMatcher);
-    }
-
-    /**
-     * Create service
-     *
-     * @param ServiceLocatorInterface $serviceLocator
-     * @return IgnoreTransactionListener
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, IgnoreTransactionListener::class);
     }
 }

--- a/src/Factory/LoggerFactory.php
+++ b/src/Factory/LoggerFactory.php
@@ -1,30 +1,17 @@
 <?php
 namespace NewRelic\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Monolog\Logger;
 use Monolog\Handler\NewRelicHandler;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
 
-class LoggerFactory implements FactoryInterface
+class LoggerFactory
 {
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container): Logger
     {
         $logger = new Logger('newrelic');
         $logger->pushHandler(new NewRelicHandler());
 
         return $logger;
-    }
-
-    /**
-     * Create service
-     *
-     * @param ServiceLocatorInterface $serviceLocator
-     * @return Logger
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, Logger::class);
     }
 }

--- a/src/Factory/ModuleOptionsFactory.php
+++ b/src/Factory/ModuleOptionsFactory.php
@@ -1,35 +1,22 @@
 <?php
 namespace NewRelic\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use NewRelic\Exception\RuntimeException;
 use NewRelic\ModuleOptions;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
 
-class ModuleOptionsFactory implements FactoryInterface
+class ModuleOptionsFactory
 {
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container): ModuleOptions
     {
         $config = $container->get('Config');
 
-        if (!isset($config['newrelic'])) {
+        if (! isset($config['newrelic'])) {
             throw new RuntimeException(
                 'NewRelic configuration must be defined. Did you copy the config file?'
             );
         }
 
         return new ModuleOptions($config['newrelic']);
-    }
-
-    /**
-     * Create service
-     *
-     * @param ServiceLocatorInterface $serviceLocator
-     * @return ModuleOptions
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, ModuleOptions::class);
     }
 }

--- a/src/Factory/RequestListenerFactory.php
+++ b/src/Factory/RequestListenerFactory.php
@@ -1,29 +1,16 @@
 <?php
 namespace NewRelic\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use NewRelic\Listener\RequestListener;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
 
-class RequestListenerFactory implements FactoryInterface
+class RequestListenerFactory
 {
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container): RequestListener
     {
         $client  = $container->get('NewRelic\Client');
         $options = $container->get('NewRelic\ModuleOptions');
 
         return new RequestListener($client, $options);
-    }
-
-    /**
-     * Create service
-     *
-     * @param ServiceLocatorInterface $serviceLocator
-     * @return RequestListener
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, RequestListener::class);
     }
 }

--- a/src/Factory/ResponseListenerFactory.php
+++ b/src/Factory/ResponseListenerFactory.php
@@ -1,29 +1,16 @@
 <?php
 namespace NewRelic\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use NewRelic\Listener\ResponseListener;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
 
-class ResponseListenerFactory implements FactoryInterface
+class ResponseListenerFactor
 {
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container): ResponseListener
     {
         $client  = $container->get('NewRelic\Client');
         $options = $container->get('NewRelic\ModuleOptions');
 
         return new ResponseListener($client, $options);
-    }
-
-    /**
-     * Create service
-     *
-     * @param ServiceLocatorInterface $serviceLocator
-     * @return ResponseListener
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, ResponseListener::class);
     }
 }

--- a/src/Factory/ResponseListenerFactory.php
+++ b/src/Factory/ResponseListenerFactory.php
@@ -4,7 +4,7 @@ namespace NewRelic\Factory;
 use Psr\Container\ContainerInterface;
 use NewRelic\Listener\ResponseListener;
 
-class ResponseListenerFactor
+class ResponseListenerFactory
 {
     public function __invoke(ContainerInterface $container): ResponseListener
     {

--- a/tests/Factory/BackgroundJobListenerFactoryTest.php
+++ b/tests/Factory/BackgroundJobListenerFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace NewRelicTest\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use NewRelic\ClientInterface;
 use NewRelic\Factory\BackgroundJobListenerFactory;
 use NewRelic\Listener\BackgroundJobListener;

--- a/tests/Factory/ErrorListenerFactoryTest.php
+++ b/tests/Factory/ErrorListenerFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace NewRelicTest\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use NewRelic\ClientInterface;
 use NewRelic\Factory\ErrorListenerFactory;
 use NewRelic\Listener\ErrorListener;

--- a/tests/Factory/IgnoreApdexListenerFactoryTest.php
+++ b/tests/Factory/IgnoreApdexListenerFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace NewRelicTest\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use NewRelic\ClientInterface;
 use NewRelic\Factory\IgnoreApdexListenerFactory;
 use NewRelic\Listener\IgnoreApdexListener;

--- a/tests/Factory/IgnoreTransactionListenerFactoryTest.php
+++ b/tests/Factory/IgnoreTransactionListenerFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace NewRelicTest\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use NewRelic\ClientInterface;
 use NewRelic\Factory\IgnoreTransactionListenerFactory;
 use NewRelic\Listener\IgnoreTransactionListener;

--- a/tests/Factory/LoggerFactoryTest.php
+++ b/tests/Factory/LoggerFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace NewRelicTest\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use NewRelic\Factory\LoggerFactory;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;

--- a/tests/Factory/ModuleOptionsFactoryTest.php
+++ b/tests/Factory/ModuleOptionsFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace NewRelicTest\Factory;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use NewRelic\Factory\ModuleOptionsFactory;
 use NewRelic\ModuleOptions;
 use PHPUnit\Framework\TestCase;

--- a/tests/Factory/ResponseListenerFactoryTest.php
+++ b/tests/Factory/ResponseListenerFactoryTest.php
@@ -1,0 +1,31 @@
+<?php
+namespace NewRelicTest\Factory;
+
+use NewRelic\Client;
+use NewRelic\Factory\ResponseListenerFactory;
+use NewRelic\Listener\ResponseListener;
+use NewRelic\ModuleOptions;
+use Psr\Container\ContainerInterface;
+use PHPUnit\Framework\TestCase;
+
+class ResponseListenerFactoryTest extends TestCase
+{
+    public function testCreateService(): void
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $client = $this->prophesize(Client::class);
+        $options = $this->prophesize(ModuleOptions::class);
+
+        $container->get(Client::class)
+            ->shouldBeCalled()
+            ->willReturn($client->reveal());
+        $container->get(ModuleOptions::class)
+            ->shouldBeCalled()
+            ->willReturn($options->reveal());
+
+        $factory = new ResponseListenerFactory();
+        $service = $factory($container->reveal());
+
+        $this->assertInstanceOf(ResponseListener::class, $service);
+    }
+}


### PR DESCRIPTION
Removed `interop-container` refactoring factories.
Factories can be simple callables, so they doesn't need the `FactoryInterface` with `service-manager > 2.7`.
`container-interop/container-interop: <1.2` in conflict key ensures that service manager is compatible with `psr/container` 